### PR TITLE
Published Manifests now contain @context and profile for images

### DIFF
--- a/external_interfaces/iiif_interface.py
+++ b/external_interfaces/iiif_interface.py
@@ -1,0 +1,29 @@
+"""Interface for interacting with IIIF services.
+"""
+
+import requests
+import validators
+
+
+class IIFInterface(object):
+    """
+    Proxy class for interacting with IIIF services.
+    """
+
+    @staticmethod
+    def get_info(iiif_base):
+        """Gets the info.json fo the given IIIF base URL.
+
+        :param iiif_base: The IIIF base URL
+        :return: dict
+        """
+        url = "%s/info.json" % (iiif_base, )
+        if not validators.url(url):
+            raise ValueError(
+                "Info URL '%s' constructed from '%s' is not valid!" % (
+                    url, iiif_base
+                )
+            )
+        resp = requests.get(url)
+        resp_json = resp.json()
+        return resp_json

--- a/features/environment.py
+++ b/features/environment.py
@@ -18,6 +18,7 @@ import settings
 import mock_data
 from iiifoo_server import create_app, db
 from external_interfaces import *
+from external_interfaces import iiif_interface
 
 
 dateformat = "%Y-%m-%d_%H-%M-%S"
@@ -97,7 +98,10 @@ settings_patcher = SettingsMocker(db_dialect="sqlite", db_host="", db_user="",
                                   db_pass="", db_port="", db_name=test_db_name,
                                   server_debug="True")
 
-patchers = [settings_patcher]
+iiif_patcher = patch.object(iiif_interface.IIFInterface, 'get_info',
+                            return_value=mock_data.iiif_info)
+
+patchers = [settings_patcher, iiif_patcher]
 
 
 def start_patching():

--- a/features/mock_data.py
+++ b/features/mock_data.py
@@ -2,3 +2,23 @@
 """
 from textwrap import dedent
 import simplejson
+
+iiif_info = {
+    'profile': [
+        'http://iiif.io/api/image/2/level1.json',
+        {
+            'supports': [
+                'regionByPct', 'sizeByForcedWh', 'sizeByWh',
+                'profileLinkHeader', 'jsonldMediaType'
+            ],
+            'qualities': ['color', 'gray'],
+            'formats': ['png']
+        }
+    ],
+    'tiles': [{'width': 1000, 'scaleFactors': [4], 'height': 1000}],
+    'protocol': 'http://iiif.io/api/image',
+    'height': 1080,
+    'width': 1920,
+    '@context': 'http://iiif.io/api/image/2/context.json',
+    '@id': 'http://iiif-host.org/iiif/image'
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ setproctitle>=1.1.8
 lxml>=3.4.1
 psycopg2>=2.5.4
 python-crontab>=1.9.3
+validators>=0.9


### PR DESCRIPTION
We were running into a problem with using the manifests generated by iiifoo with the Mirador viewer and version 2.0 of the IIIF Image API. Mirador was unable to determine the API version due to the absence of the @context and profile fields.

This pull request adds the missing fields along with some mock data for tests.
